### PR TITLE
Thesis #3: Inline utils.startsWith for delimiter check

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function parseMatter(file, options) {
 
   // get the length of the opening delimiter
   const openLen = open.length;
-  if (!utils.startsWith(str, open, openLen)) {
+  if (str.slice(0, openLen) !== open) {
     excerpt(file, opts);
     return file;
   }


### PR DESCRIPTION
References #3

Self-reported metric: 896586.0000
Baseline: 849858.0000
Summary: Inlined utils.startsWith at line 69 to eliminate function call overhead. Changed to direct string slice comparison, resulting in ~5.5% performance improvement.